### PR TITLE
Fix ConcurrentModificationException error.

### DIFF
--- a/src/main/java/fi/dy/masa/litematica/render/schematic/WorldRendererSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/WorldRendererSchematic.java
@@ -793,11 +793,11 @@ public class WorldRendererSchematic
                     if (chunk != null && data instanceof ChunkRenderDataSchematic &&
                         data.getTimeBuilt() >= chunk.getTimeCreated())
                     {
-                        for (BlockEntity te : tiles)
+                        for (int i = 0; i < tiles.size(); i++)
                         {
                             try
                             {
-                                BlockEntityRenderDispatcher.INSTANCE.render(te, partialTicks, -1);
+                                BlockEntityRenderDispatcher.INSTANCE.render(tiles.get(i), partialTicks, -1);
                             }
                             catch (Exception e)
                             {


### PR DESCRIPTION
#69

Uses a simple for loop with an incrementing index rather than using an Iterator. This prevents an error from being thrown if the list has been changed while iterating.