### PR TITLE
Added blockType-matching in "WrongBlock" overlay

### DIFF
--- a/src/main/java/fi/dy/masa/litematica/config/Configs.java
+++ b/src/main/java/fi/dy/masa/litematica/config/Configs.java
@@ -78,6 +78,7 @@ public class Configs implements IConfigHandler
 
     public static class Visuals
     {
+    	public static final ConfigString        EQUIVALENT_BLOCK_TYPE_SUBSTITUTE    = new ConfigString("equivalentBlockTypeSubstitute", "", "Defined equivalent blocks can substitute each other.\nThis should be a valid json array containing regex expression(s).\ne.g. [\"minecraft:(stone|dirt)\", \"minecraft:(iron|gold|diamond)_block\"] \nso that no Wrong-Block overlay will be shown if you substitute dirt/stone, or iron/gold/diamond block for each other blocktypes");
         public static final ConfigBoolean       ENABLE_AREA_SELECTION_RENDERING     = new ConfigBoolean("enableAreaSelectionBoxesRendering", true, "Enable Area Selection boxes rendering", "Area Selection Boxes Rendering");
         public static final ConfigBoolean       ENABLE_PLACEMENT_BOXES_RENDERING    = new ConfigBoolean("enablePlacementBoxesRendering", true, "Enable Schematic Placement boxes rendering", "Schematic Placement Boxes Rendering");
         public static final ConfigBoolean       ENABLE_RENDERING                    = new ConfigBoolean("enableRendering", true, "Main rendering toggle option. Enables/disables ALL mod rendering.", "All Rendering");
@@ -110,6 +111,7 @@ public class Configs implements IConfigHandler
         public static final ConfigBoolean       SCHEMATIC_VERIFIER_BLOCK_MODELS     = new ConfigBoolean("schematicVerifierUseBlockModels", false, "Forces using blocks models for everything in the Schematic Verifier\nresult list. Normally item models are used for anything\nthat has an item, and block models are only used for blocks\nthat don't have an item, plus for Flower Pots to see the contained item.");
 
         public static final ImmutableList<IConfigBase> OPTIONS = ImmutableList.of(
+                EQUIVALENT_BLOCK_TYPE_SUBSTITUTE,
                 ENABLE_RENDERING,
                 ENABLE_SCHEMATIC_RENDERING,
 

--- a/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRendererSchematicVbo.java
+++ b/src/main/java/fi/dy/masa/litematica/render/schematic/ChunkRendererSchematicVbo.java
@@ -31,6 +31,7 @@ import net.minecraft.world.chunk.WorldChunk;
 import fi.dy.masa.litematica.config.Configs;
 import fi.dy.masa.litematica.data.DataManager;
 import fi.dy.masa.litematica.render.RenderUtils;
+import fi.dy.masa.litematica.util.BlockMatchingUtils;
 import fi.dy.masa.litematica.util.OverlayType;
 import fi.dy.masa.litematica.util.PositionUtils;
 import fi.dy.masa.litematica.world.WorldSchematic;
@@ -661,6 +662,9 @@ public class ChunkRendererSchematicVbo
                 // Wrong block
                 else if (stateSchematic.getBlock() != stateClient.getBlock())
                 {
+                    if (BlockMatchingUtils.isTwoBlockTypesMatching(stateSchematic, stateClient)){
+                        return OverlayType.NONE;
+                    }
                     return OverlayType.WRONG_BLOCK;
                 }
                 // Wrong state

--- a/src/main/java/fi/dy/masa/litematica/util/BlockMatchingUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/BlockMatchingUtils.java
@@ -1,0 +1,115 @@
+package fi.dy.masa.litematica.util;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+import com.google.gson.reflect.TypeToken;
+import fi.dy.masa.litematica.config.Configs;
+import net.minecraft.block.BlockState;
+import net.minecraft.state.property.Property;
+import net.minecraft.util.registry.Registry;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public class BlockMatchingUtils {
+    private static final Gson gson = new Gson();
+    private static String lastBadInputBlockTypeMatchingJson = "";
+    private static String lastBadInputBlockStateMatchingJson = "";
+
+    private static List<String> parseBlockTypeMatchingJson(String jsonString) {
+        List<String> jsonList;
+        if (jsonString.equals(lastBadInputBlockTypeMatchingJson)) {
+            return null;
+        }
+        try {
+            jsonList = gson.fromJson(jsonString, new TypeToken<List<String>>() {
+            }.getType());
+            //jsonList.forEach(System.out::println);
+        } catch (JsonParseException e) {
+            jsonList = null;
+            lastBadInputBlockTypeMatchingJson = jsonString;
+        }
+        return jsonList;
+    }
+
+    private static List<String> parseBlockStateMatchingJson(String jsonString) {
+        List<String> jsonList = null;
+        if (jsonString.equals(lastBadInputBlockStateMatchingJson)) {
+            return null;
+        }
+        try {
+            jsonList = gson.fromJson(jsonString, new TypeToken<List<String>>() {
+            }.getType());
+            //jsonList.forEach(System.out::println);
+        } catch (JsonParseException ignored) {
+        }
+        if (jsonList == null) {
+            lastBadInputBlockStateMatchingJson = jsonString;
+        }
+        return jsonList;
+    }
+
+    public static boolean isTwoBlockTypesMatching(BlockState blockState1, BlockState blockState2) {
+        String inputOptionString = Configs.Visuals.EQUIVALENT_BLOCK_TYPE_SUBSTITUTE.getStringValue();
+        if (inputOptionString.isEmpty()) {
+            return false;
+        }
+        List<String> blockTypeMatchingRegexList = parseBlockTypeMatchingJson(inputOptionString);
+        if (blockTypeMatchingRegexList == null) {
+            return false;
+        }
+        for (String s : blockTypeMatchingRegexList) {
+            if (Registry.BLOCK.getId(blockState1.getBlock()).toString().matches(s)) {
+                if (Registry.BLOCK.getId(blockState2.getBlock()).toString().matches(s)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /*
+    public static boolean isTwoBlockStatesMatching(BlockState blockState1, BlockState blockState2) {
+        String inputOptionString = Configs.Visuals.EQUIVALENT_BLOCK_STATE_SUBSTITUTE.getStringValue();
+        if (inputOptionString.isEmpty()) {
+            return false;
+        }
+        List<String> blockStateMatchingRegexList = parseBlockStateMatchingJson(inputOptionString);
+        if (blockStateMatchingRegexList == null) {
+            return false;
+        }
+        List<String> blockProps2 = getFormattedBlockStatePropertiesWithBlockTypeBase(blockState2);
+        AtomicReference<Boolean> flag = new AtomicReference<>(false);
+        getFormattedBlockStatePropertiesWithBlockTypeBase(blockState1).forEach(s -> {
+            blockStateMatchingRegexList.forEach(r -> {
+                if (s.matches(r)){
+                    blockProps2.forEach(s2 -> {
+                        if (s2.matches(r)){
+                            flag.set(true);
+                        }
+                    });
+                }
+            });
+        });
+
+        return flag.get();
+    }
+     */
+
+    private static List<String> getFormattedBlockStatePropertiesWithBlockTypeBase(BlockState state) {
+        Collection<Property<?>> properties = state.getProperties();
+        String separator = ":";
+        if (properties.size() > 0) {
+            List<String> lines = new ArrayList<>();
+            for (Property<?> prop : properties) {
+                Comparable<?> val = state.get(prop);
+                lines.add(Registry.BLOCK.getId(state.getBlock()).toString() +"["+ prop.getName() + separator + val.toString() +"]");
+                // the format is like "BlockType[blockPropName:blockPropValue]"
+            }
+            return lines;
+        }
+        return Collections.emptyList();
+    }
+}


### PR DESCRIPTION
Input an Json array of Strings, each working as a RegEx.
E.g.:          ["minecraft:(sand|red_sand)","minecraft:(stone|cobblestone|dirt)"]
![image](https://user-images.githubusercontent.com/35984104/81763463-e3592e80-9501-11ea-9ed6-3f543b85f50c.png)

Thus, you can place a sand in the position where there's a redsand in schematic, without RED WRONG_BLOCK overlay being rendered. So are stone, cobblestone and dirt blocks.

![image](https://user-images.githubusercontent.com/35984104/81763678-5fec0d00-9502-11ea-9c88-b9df43cb118a.png)
![image](https://user-images.githubusercontent.com/35984104/81763711-6da19280-9502-11ea-9a79-056d5c5726e9.png)


  