### PR TITLE
Added missing block override for grass path

### DIFF
--- a/src/main/java/fi/dy/masa/litematica/materials/MaterialCache.java
+++ b/src/main/java/fi/dy/masa/litematica/materials/MaterialCache.java
@@ -218,6 +218,10 @@ public class MaterialCache
         {
             return new ItemStack(Blocks.DIRT);
         }
+        else if (block == Blocks.GRASS_PATH)
+        {
+            return new ItemStack(Blocks.GRASS);
+        }
         else if (block == Blocks.BROWN_MUSHROOM_BLOCK)
         {
             return new ItemStack(Blocks.BROWN_MUSHROOM_BLOCK);


### PR DESCRIPTION
fixed grass_path override in MaterialCache.getRequiredBuildItemForState()

(cherry picked from commit e83fde18112c8f1f2146b93acd4a1dd71bbf9305)