### PR TITLE
Update TaskPasteSchematicPerChunkCommand.java

### DIFF
--- a/src/main/java/fi/dy/masa/litematica/scheduler/tasks/TaskPasteSchematicPerChunkCommand.java
+++ b/src/main/java/fi/dy/masa/litematica/scheduler/tasks/TaskPasteSchematicPerChunkCommand.java
@@ -229,7 +229,7 @@ public class TaskPasteSchematicPerChunkCommand extends TaskPasteSchematicPerChun
                 String nbtString = nbt.toString();
                 */
 
-                String strCommand = String.format(Locale.ROOT, "/summon %s %f %f %f", entityName, entity.posX, entity.posY, entity.posZ);
+                String strCommand = String.format(Locale.ROOT, "/minecraft:summon %s %f %f %f", entityName, entity.posX, entity.posY, entity.posZ);
                 /*
                 String strCommand = String.format("/summon %s %f %f %f %s", entityName, entity.posX, entity.posY, entity.posZ, nbtString);
                 System.out.printf("entity: %s\n", entity);


### PR DESCRIPTION
In spigot or paper servers the /summon or /setblock command would not work properly (as they have their own /summon). use /minecraft:summon could solve the problem. This would not affect the vanilla server.

Of course the best solution is to create a new config though...like /setblock.