### PR TITLE
Adds interval configuration for halting easyPlace on inventory swap

### DIFF
--- a/src/main/java/fi/dy/masa/litematica/config/Configs.java
+++ b/src/main/java/fi/dy/masa/litematica/config/Configs.java
@@ -39,6 +39,7 @@ public class Configs implements IConfigHandler
         public static final ConfigBoolean       EASY_PLACE_MODE         = new ConfigBoolean(    "easyPlaceMode", false, "When enabled, then simply trying to use an item/place a block\non schematic blocks will place that block in that position");
         public static final ConfigBoolean       EASY_PLACE_SP_HANDLING  = new ConfigBoolean(    "easyPlaceSinglePlayerHandling", true, "If enabled, then Litematica handles the so called\n\"Carpet mod Accurate Placement Protocol\" itself in single player.\nIf you also have Tweakeroo installed, then this can be disabled,\nas Tweakeroo's 'clientPlacementRotation' option does the exact same thing.");
         public static final ConfigBoolean       EASY_PLACE_PROTOCOL_V3  = new ConfigBoolean(    "easyPlaceProtocolV3", true, "If enabled, then Litematica uses \"version 3\"\nof the so-called \"accurate placement protocol\".\nThis is currently only supported by Litematica itself (in single player).");
+        public static final ConfigInteger       EASY_PLACE_SWAP_INTERVAL = new ConfigInteger(    "easyPlaceSwapInterval", 0, 0, 10000, "The interval in milliseconds the Easy Place mode waits\nafter swapping inventory slots and placing a block.\nUseful to avoid placing wrong blocks when having high ping.");
         public static final ConfigBoolean       EXECUTE_REQUIRE_TOOL    = new ConfigBoolean(    "executeRequireHoldingTool", true, "Require holding an enabled tool item\nfor the executeOperation hotkey to work");
         public static final ConfigBoolean       FIX_RAIL_ROTATION       = new ConfigBoolean(    "fixRailRotation", true, "If true, then a fix is applied for the vanilla bug in rails,\nwhere the 180 degree rotations of straight north-south and\neast-west rails rotate 90 degrees counterclockwise instead >_>");
         public static final ConfigBoolean       GENERATE_LOWERCASE_NAMES = new ConfigBoolean(   "generateLowercaseNames", false, "If enabled, then by default the suggested schematic names\nwill be lowercase and using underscores instead of spaces");
@@ -93,6 +94,7 @@ public class Configs implements IConfigHandler
                 PASTE_REPLACE_BEHAVIOR,
                 SELECTION_CORNERS_MODE,
 
+                EASY_PLACE_SWAP_INTERVAL,
                 PASTE_COMMAND_INTERVAL,
                 PASTE_COMMAND_LIMIT,
                 PASTE_COMMAND_SETBLOCK,

--- a/src/main/java/fi/dy/masa/litematica/util/InventoryUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/InventoryUtils.java
@@ -90,6 +90,8 @@ public class InventoryUtils
                 {
                     fi.dy.masa.malilib.util.InventoryUtils.swapItemToMainHand(stack.copy(), mc);
                 }
+
+                WorldUtils.refreshEasyPlaceLastSwap();
             }
         }
     }

--- a/src/main/java/fi/dy/masa/litematica/util/WorldUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/WorldUtils.java
@@ -77,6 +77,7 @@ import fi.dy.masa.malilib.util.SubChunkPos;
 public class WorldUtils
 {
     private static final List<PositionCache> EASY_PLACE_POSITIONS = new ArrayList<>();
+    private static long EASY_PLACE_LAST_SWAP = 0;
 
     public static boolean shouldPreventBlockUpdates(World world)
     {
@@ -437,6 +438,12 @@ public class WorldUtils
 
             // Already placed to that position, possible server sync delay
             if (easyPlaceIsPositionCached(pos))
+            {
+                return ActionResult.FAIL;
+            }
+
+            // Ignore action if too fast
+            if (easyPlaceIsTooFast())
             {
                 return ActionResult.FAIL;
             }
@@ -1032,5 +1039,15 @@ public class WorldUtils
         {
             return currentTime - this.time > this.timeout;
         }
+    }
+
+    private static boolean easyPlaceIsTooFast()
+    {
+        return (EASY_PLACE_LAST_SWAP > 0 && System.nanoTime() - EASY_PLACE_LAST_SWAP < 1000000L * Configs.Generic.EASY_PLACE_SWAP_INTERVAL.getIntegerValue());
+    }
+
+    public static void refreshEasyPlaceLastSwap()
+    {
+        EASY_PLACE_LAST_SWAP = System.nanoTime();
     }
 }


### PR DESCRIPTION
- When on high ping, servers may misplace a block with what was in the hotbar before the swap happened
- Tested in an Airplane server