### PR TITLE
1.17 easy mode restricted protocol

### DIFF
--- a/src/main/java/fi/dy/masa/litematica/config/Configs.java
+++ b/src/main/java/fi/dy/masa/litematica/config/Configs.java
@@ -41,7 +41,7 @@ public class Configs implements IConfigHandler
         public static final ConfigBoolean       EASY_PLACE_HOLD_ENABLED = new ConfigBoolean(    "easyPlaceHoldEnabled", true, "When enabled, then you can hold down the use key\nand look at different schematic blocks to place them,\nwithout having to click on every block individually.");
         public static final ConfigBoolean       EASY_PLACE_MODE         = new ConfigBoolean(    "easyPlaceMode", false, "When enabled, then simply trying to use an item/place a block\non schematic blocks will place that block in that position");
         public static final ConfigBoolean       EASY_PLACE_SP_HANDLING  = new ConfigBoolean(    "easyPlaceSinglePlayerHandling", true, "If enabled, then Litematica handles the so called\n\"Carpet mod Accurate Block Placement Protocol\" itself in single player.\nIf you also have Tweakeroo installed, then this can be disabled,\nas Tweakeroo's 'clientPlacementRotation' option does the exact same thing.");
-        public static final ConfigOptionList    EASY_PLACE_PROTOCOL     = new ConfigOptionList( "easyPlaceProtocolVersion", EasyPlaceProtocol.AUTO, "The type of \"accurate placement protocol\" to use.\n- Auto: Uses v3 in single player, and Slabs-only in multiplayer.\n- Version 3: Only supported by Litematica itself (in single player).\n- Version 2: Compatible with Carpet mod.\n- Slabs only: Only fixes top slabs. Compatible with Paper servers.\n- None: Does not modify coordinates.");
+        public static final ConfigOptionList    EASY_PLACE_PROTOCOL     = new ConfigOptionList( "easyPlaceProtocolVersion", EasyPlaceProtocol.AUTO, "The type of \"accurate placement protocol\" to use.\n- Auto: Uses v3 in single player, and Slabs-only in multiplayer.\n- Version 3: Only supported by Litematica itself (in single player).\n- Version 2: Compatible with Carpet mod.\n- Slabs only: Only fixes top slabs. Compatible with Paper servers.\n- Restricted: Places what is possible in Paper servers or fails when player's orientation does not match.\n- None: Does not modify coordinates.");
         public static final ConfigInteger       EASY_PLACE_SWAP_INTERVAL = new ConfigInteger(    "easyPlaceSwapInterval", 0, 0, 10000, "The interval in milliseconds the Easy Place mode waits\nafter swapping inventory slots and placing a block.\nUseful to avoid placing wrong blocks when having high ping.");
         public static final ConfigBoolean       EASY_PLACE_VANILLA_REACH  = new ConfigBoolean(    "easyPlaceVanillaReach", false, "If enabled, reduces reach distance from 6 to 4.5\nso servers don't reject placement of far blocks.");
         public static final ConfigBoolean       EXECUTE_REQUIRE_TOOL    = new ConfigBoolean(    "executeRequireHoldingTool", true, "Require holding an enabled tool item\nfor the executeOperation hotkey to work");
@@ -195,6 +195,7 @@ public class Configs implements IConfigHandler
         public static final ConfigOptionList    BLOCK_INFO_OVERLAY_ALIGNMENT        = new ConfigOptionList( "blockInfoOverlayAlignment", BlockInfoAlignment.TOP_CENTER, "The alignment of the Block Info Overlay");
         public static final ConfigInteger       BLOCK_INFO_OVERLAY_OFFSET_Y         = new ConfigInteger(    "blockInfoOverlayOffsetY", 6, -2000, 2000, "The y offset of the block info overlay from the selected edge");
         public static final ConfigBoolean       BLOCK_INFO_OVERLAY_ENABLED          = new ConfigBoolean(    "blockInfoOverlayEnabled", true, "Enable Block Info Overlay rendering to show info\nabout the looked-at block or verifier error marker,\nwhile holding the 'renderInfoOverlay' key", "Block Info Overlay Rendering");
+        public static final ConfigBoolean       EASY_PLACE_WARN                     = new ConfigBoolean(    "easyPlaceWarn", true, "If enabled, Easy Place warns if a block could not be placed by it.");
         public static final ConfigOptionList    INFO_HUD_ALIGNMENT                  = new ConfigOptionList( "infoHudAlignment", HudAlignment.BOTTOM_RIGHT, "The alignment of the \"Info HUD\",\nused for the Material List, Schematic Verifier mismatch positions etc.");
         public static final ConfigInteger       INFO_HUD_MAX_LINES                  = new ConfigInteger(    "infoHudMaxLines", 10, 1, 128, "The maximum number of info lines to show on the HUD at once");
         public static final ConfigInteger       INFO_HUD_OFFSET_X                   = new ConfigInteger(    "infoHudOffsetX", 1, 0, 32000, "The X offset of the Info HUD from the screen edge");
@@ -222,6 +223,7 @@ public class Configs implements IConfigHandler
                 STATUS_INFO_HUD_AUTO,
                 VERIFIER_OVERLAY_ENABLED,
                 WARN_DISABLED_RENDERING,
+                EASY_PLACE_WARN,
 
                 BLOCK_INFO_LINES_ALIGNMENT,
                 BLOCK_INFO_OVERLAY_ALIGNMENT,

--- a/src/main/java/fi/dy/masa/litematica/util/EasyPlaceProtocol.java
+++ b/src/main/java/fi/dy/masa/litematica/util/EasyPlaceProtocol.java
@@ -10,6 +10,7 @@ public enum EasyPlaceProtocol implements IConfigOptionListEntry
     V3                  ("v3",                    "litematica.gui.label.easy_place_protocol.v3"),
     V2                  ("v2",                    "litematica.gui.label.easy_place_protocol.v2"),
     SLAB_ONLY           ("slabs_only",            "litematica.gui.label.easy_place_protocol.slabs_only"),
+    RESTRICTED          ("restricted",            "litematica.gui.label.easy_place_protocol.restricted"),
     NONE                ("none",                  "litematica.gui.label.easy_place_protocol.none");
 
     public static final ImmutableList<EasyPlaceProtocol> VALUES = ImmutableList.copyOf(values());

--- a/src/main/java/fi/dy/masa/litematica/util/WorldUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/WorldUtils.java
@@ -10,12 +10,22 @@ import java.util.Comparator;
 import java.util.List;
 import javax.annotation.Nullable;
 import com.mojang.datafixers.DataFixer;
+import net.minecraft.block.AbstractBannerBlock;
+import net.minecraft.block.AbstractSignBlock;
+import net.minecraft.block.AbstractSkullBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.ComparatorBlock;
 import net.minecraft.block.RepeaterBlock;
 import net.minecraft.block.SlabBlock;
+import net.minecraft.block.TorchBlock;
+import net.minecraft.block.WallBannerBlock;
+import net.minecraft.block.WallRedstoneTorchBlock;
+import net.minecraft.block.WallSignBlock;
+import net.minecraft.block.WallSkullBlock;
+import net.minecraft.block.WallTorchBlock;
+import net.minecraft.block.enums.Attachment;
 import net.minecraft.block.enums.BlockHalf;
 import net.minecraft.block.enums.ComparatorMode;
 import net.minecraft.block.enums.SlabType;
@@ -71,6 +81,8 @@ import fi.dy.masa.malilib.util.IntBoundingBox;
 import fi.dy.masa.malilib.util.LayerRange;
 import fi.dy.masa.malilib.util.StringUtils;
 import fi.dy.masa.malilib.util.SubChunkPos;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 
 public class WorldUtils
 {
@@ -395,7 +407,10 @@ public class WorldUtils
 
             if (result == ActionResult.FAIL)
             {
-                InfoUtils.showGuiOrInGameMessage(MessageType.WARNING, "litematica.message.easy_place_fail");
+                if (Configs.InfoOverlays.EASY_PLACE_WARN.getBooleanValue())
+                {
+                    InfoUtils.showGuiOrInGameMessage(MessageType.WARNING, "litematica.message.easy_place_fail");
+                }
                 return true;
             }
 
@@ -474,6 +489,11 @@ public class WorldUtils
                 Vec3d hitPos = trace.getPos();
                 Direction sideOrig = trace.getSide();
 
+                if (Configs.Generic.DEBUG_LOGGING.getBooleanValue())
+                {
+                    Litematica.logger.info("sideTrace: " + sideOrig + " hitPosTrace: " + hitPos);
+                }
+
                 // If there is a block in the world right behind the targeted schematic block, then use
                 // that block as the click position
                 if (traceVanilla != null && traceVanilla.getType() == HitResult.Type.BLOCK)
@@ -497,8 +517,20 @@ public class WorldUtils
                     }
                 }
 
-                Direction side = applyPlacementFacing(stateSchematic, sideOrig, stateClient);
+                if (Configs.Generic.DEBUG_LOGGING.getBooleanValue())
+                {
+                    Litematica.logger.info("sideIn: " + sideOrig + " hitPosIn: " + hitPos);
+                }
+
                 EasyPlaceProtocol protocol = PlacementHandler.getEffectiveProtocolVersion();
+
+                BlockPos posOut = pos;
+                Direction sideOut = sideOrig;
+                
+                if (protocol != EasyPlaceProtocol.RESTRICTED)
+                {
+                	sideOut = applyPlacementFacing(stateSchematic, sideOrig, stateClient);
+                }
 
                 if (protocol == EasyPlaceProtocol.V3)
                 {
@@ -514,14 +546,33 @@ public class WorldUtils
                     // Slab support only
                     hitPos = applyBlockSlabProtocol(pos, stateSchematic, hitPos);
                 }
+                else if (protocol == EasyPlaceProtocol.RESTRICTED)
+                {
+                    //Use vanilla / Paper restrictions
+                    var changedHitResult = applyRestrictedProtocol(pos, stateSchematic, sideOrig, hitPos, mc, hand);
+                    if (changedHitResult == null)
+                    {
+                        if (Configs.Generic.DEBUG_LOGGING.getBooleanValue())
+                        {
+                            Litematica.logger.info("Can't orientate");
+                        }
+                        return ActionResult.FAIL;
+                    }
+
+                    posOut = changedHitResult.getLeft();
+                    sideOut = changedHitResult.getMiddle();
+                    hitPos = changedHitResult.getRight();
+                }
 
                 // Mark that this position has been handled (use the non-offset position that is checked above)
                 cacheEasyPlacePosition(pos);
 
-                BlockHitResult hitResult = new BlockHitResult(hitPos, side, pos, false);
+                BlockHitResult hitResult = new BlockHitResult(hitPos, sideOut, posOut, false);
 
-                //System.out.printf("pos: %s side: %s, hit: %s\n", pos, side, hitPos);
-                // pos, side, hitPos
+                if (Configs.Generic.DEBUG_LOGGING.getBooleanValue())
+                {
+                    Litematica.logger.info("sideOut: " + sideOut + " hitPosOut: " + hitPos + " posOut: " + posOut);
+                }
                 mc.interactionManager.interactBlock(mc.player, mc.world, hand, hitResult);
 
                 if (stateSchematic.getBlock() instanceof SlabBlock && stateSchematic.get(SlabBlock.TYPE) == SlabType.DOUBLE)
@@ -530,8 +581,8 @@ public class WorldUtils
 
                     if (stateClient.getBlock() instanceof SlabBlock && stateClient.get(SlabBlock.TYPE) != SlabType.DOUBLE)
                     {
-                        side = applyPlacementFacing(stateSchematic, sideOrig, stateClient);
-                        hitResult = new BlockHitResult(hitPos, side, pos, false);
+                        sideOut = applyPlacementFacing(stateSchematic, sideOrig, stateClient);
+                        hitResult = new BlockHitResult(hitPos, sideOut, pos, false);
                         mc.interactionManager.interactBlock(mc.player, mc.world, hand, hitResult);
                     }
                 }
@@ -658,6 +709,239 @@ public class WorldUtils
         }
 
         return new Vec3d(x, y, z);
+    }
+
+    private static boolean isMatchingStateRestrictedProtocol (BlockState state1, BlockState state2)
+    {
+        if (state1 == null || state2 == null)
+        {
+            return false;
+        }
+
+        if (state1 == state2)
+        {
+            return true;
+        }
+
+        var orientationProperties = new Property<?>[] {
+                Properties.FACING, //pistons
+                Properties.BLOCK_HALF, //stairs, trapdoors
+                Properties.HOPPER_FACING,
+                Properties.DOOR_HINGE,
+                Properties.HORIZONTAL_FACING, //small dripleaf
+                Properties.AXIS, //logs
+                Properties.SLAB_TYPE,
+                Properties.VERTICAL_DIRECTION,
+                Properties.ROTATION, //banners
+                Properties.HANGING, //lanterns
+                Properties.WALL_MOUNT_LOCATION, //lever
+                Properties.ATTACHMENT, //bell (double-check for single-wall / double-wall)
+                //Properties.HORIZONTAL_AXIS, //Nether portals, though they aren't directly placeable
+                //Properties.ORIENTATION, //jigsaw blocks
+        };
+
+        for (var property : orientationProperties)
+        {
+            boolean hasProperty1 = state1.contains(property);
+            boolean hasProperty2 = state2.contains(property);
+
+            if (hasProperty1 != hasProperty2)
+                return false;
+            if (!hasProperty1)
+                continue;
+
+            if (state1.get(property) != state2.get(property))
+                return false;
+        }
+
+        //Other properties are considered as matching
+        return true;
+    }
+
+    private static Triple<BlockPos, Direction, Vec3d> applyRestrictedProtocol(BlockPos pos, BlockState stateSchematic, Direction sideIn, Vec3d hitVecIn, MinecraftClient mc, Hand hand)
+    {
+        ItemPlacementContext ctx;
+
+        //Handle axis and slabs first, as they are exclusive with other orientation properties
+        if (stateSchematic.contains(Properties.AXIS))
+        {
+            var orientation = getAxisOrientation(pos, stateSchematic, sideIn, hitVecIn);
+            if (orientation == null)
+                return null;
+            return Triple.of(pos, orientation.getLeft(), orientation.getRight());
+        }
+        if (stateSchematic.contains(Properties.SLAB_TYPE))
+        {
+            var orientation = getSlabOrientation(stateSchematic, sideIn, hitVecIn);
+            return Triple.of(pos, orientation.getLeft(), orientation.getRight());
+        }
+
+        //Last types are interdependent
+        Vec3d hitVecOut = hitVecIn;
+        Direction sideOut = sideIn;
+
+        //Handle attachment (bell)
+        if (stateSchematic.contains(Properties.ATTACHMENT)) {
+            var property = stateSchematic.get(Properties.ATTACHMENT);
+            if (property == Attachment.CEILING)
+            {
+                sideOut = Direction.DOWN;
+            }
+            else if (property == Attachment.FLOOR)
+            {
+                sideOut = Direction.UP;
+            }
+            else
+            {
+                if (stateSchematic.contains(Properties.HORIZONTAL_FACING))
+                {
+                    sideOut = stateSchematic.get(Properties.HORIZONTAL_FACING).getOpposite();
+                }
+            }
+        }
+
+        if (stateSchematic.contains(Properties.BLOCK_HALF))
+        {
+            //use floored coordinates
+            double x = pos.getX();
+            double y = pos.getY();
+            double z = pos.getZ();
+
+            if (stateSchematic.get(Properties.BLOCK_HALF) == BlockHalf.TOP)
+            {
+                y += 0.9;
+                sideOut = Direction.DOWN;
+            }
+            else
+            {
+                sideOut = Direction.UP;
+            }
+
+            //Check with getPlacementState
+            hitVecOut = new Vec3d(x, y, z);
+        }
+
+        var block = stateSchematic.getBlock();
+        if (block instanceof TorchBlock) //Torch, Soul Torch, Redstone Torch
+        {
+            boolean isOnWall = block instanceof WallTorchBlock || block instanceof WallRedstoneTorchBlock;
+            return getWallPlaceableOrientation(pos, stateSchematic, hitVecOut, mc, hand, isOnWall);
+        }
+        else if (block instanceof AbstractBannerBlock)
+        {
+            boolean isOnWall = block instanceof WallBannerBlock;
+            return getWallPlaceableOrientation(pos, stateSchematic, hitVecOut, mc, hand, isOnWall);
+        }
+        else if (block instanceof AbstractSignBlock)
+        {
+            boolean isOnWall = block instanceof WallSignBlock;
+            return getWallPlaceableOrientation(pos, stateSchematic, hitVecOut, mc, hand, isOnWall);
+        }
+        else if (block instanceof AbstractSkullBlock) //Wither Skull, Player Skull
+        {
+            boolean isOnWall = block instanceof WallSkullBlock;
+            return getWallPlaceableOrientation(pos, stateSchematic, hitVecOut, mc, hand, isOnWall);
+        }
+
+        var updatedHitResult = new BlockHitResult(hitVecOut, sideOut, pos, false);
+        ctx = new ItemPlacementContext(mc.player, hand, mc.player.getStackInHand(hand), updatedHitResult);
+        var attemptState = stateSchematic.getBlock().getPlacementState(ctx);
+        if (isMatchingStateRestrictedProtocol (attemptState, stateSchematic))
+            return Triple.of(pos, sideOut, hitVecOut);
+        else
+            return null; //give up
+    }
+
+    private static Triple<BlockPos, Direction, Vec3d> getWallPlaceableOrientation(BlockPos pos, BlockState stateSchematic, Vec3d hitVecOut, MinecraftClient mc, Hand hand, boolean isOnWall) {
+        Direction sideOut;
+        BlockPos posOrig = pos;
+
+        if (isOnWall)
+        {
+            if (!stateSchematic.contains(Properties.HORIZONTAL_FACING))
+            {
+                //Shouldn't happen, fail instead of crashing just in case
+                return null;
+            }
+
+            sideOut = stateSchematic.get(Properties.HORIZONTAL_FACING);
+            pos = pos.offset(sideOut.getOpposite());
+        }
+        else
+        {
+            sideOut = Direction.UP;
+            pos = pos.down();
+        }
+        BlockState stateFacing = mc.world.getBlockState(pos);
+
+        if (stateFacing == null || stateFacing.isAir())
+            return null;
+
+        //Check for blocks that have rotation property (Banners, Signs, Skulls)
+        if (stateSchematic.contains(Properties.ROTATION))
+        {
+            var updatedHitResult = new BlockHitResult(hitVecOut, sideOut, posOrig, false);
+            var ctx = new ItemPlacementContext(mc.player, hand, mc.player.getStackInHand(hand), updatedHitResult);
+            var attemptState = stateSchematic.getBlock().getPlacementState(ctx);
+            if (!isMatchingStateRestrictedProtocol (attemptState, stateSchematic))
+                return null;
+        }
+
+        return Triple.of(pos, sideOut, hitVecOut);
+    }
+
+    private static Pair<Direction, Vec3d> getAxisOrientation(BlockPos pos, BlockState stateSchematic, Direction sideIn, Vec3d hitVecIn) {
+        var property = stateSchematic.get(Properties.AXIS);
+        if (property == Direction.Axis.Y)
+        {
+            if (sideIn == Direction.DOWN || sideIn == Direction.UP)
+            {
+                //Side already correct
+                return Pair.of(sideIn, hitVecIn);
+            }
+
+            //Wrong side - check which direction to use
+            return Pair.of(hitVecIn.y - pos.getY() < 0.5 ? Direction.DOWN : Direction.UP, hitVecIn);
+        }
+        else if (property == Direction.Axis.X)
+        {
+            if (sideIn == Direction.WEST || sideIn == Direction.EAST)
+            {
+                //Side already correct
+                return Pair.of(sideIn, hitVecIn);
+            }
+
+            //Wrong side - check which direction to use
+            return Pair.of(hitVecIn.x - pos.getX() < 0.5 ? Direction.WEST : Direction.EAST, hitVecIn);
+        }
+        else if (property == Direction.Axis.Z)
+        {
+            if (sideIn == Direction.NORTH || sideIn == Direction.SOUTH)
+            {
+                //Side already correct
+                return Pair.of(sideIn, hitVecIn);
+            }
+
+            //Wrong side - check which direction to use
+            return Pair.of(hitVecIn.z - pos.getZ() < 0.5 ? Direction.NORTH : Direction.SOUTH, hitVecIn);
+        }
+        return null;
+    }
+    private static Pair<Direction, Vec3d> getSlabOrientation(BlockState stateSchematic, Direction sideIn, Vec3d hitVecIn) {
+        var property = stateSchematic.get(Properties.SLAB_TYPE);
+
+        if (property == SlabType.TOP)
+        {
+            return Pair.of(Direction.DOWN, new Vec3d(hitVecIn.x, hitVecIn.y + 0.9, hitVecIn.z));
+        }
+        else if (property == SlabType.BOTTOM)
+        {
+            return Pair.of(Direction.UP, hitVecIn);
+        }
+        else
+        {
+            return Pair.of(sideIn, hitVecIn);
+        }
     }
 
     public static <T extends Comparable<T>> Vec3d applyPlacementProtocolV3(BlockPos pos, BlockState state, Vec3d hitVecIn)

--- a/src/main/java/fi/dy/masa/litematica/util/WorldUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/WorldUtils.java
@@ -713,19 +713,13 @@ public class WorldUtils
 
     private static boolean isMatchingStateRestrictedProtocol (BlockState state1, BlockState state2)
     {
-        Litematica.logger.info("Restricted protocol: state1 " + state1);
-        Litematica.logger.info("Restricted protocol: state2 " + state2);
-
         if (state1 == null || state2 == null)
         {
             return false;
         }
 
-        Litematica.logger.info(state1.getBlock().getClass().getSimpleName());
-        Litematica.logger.info(state2.getBlock().getClass().getSimpleName());
-
-        if (state1 == state2) {
-            Litematica.logger.info("Restricted protocol: matching same pointers");
+        if (state1 == state2)
+        {
             return true;
         }
 
@@ -756,24 +750,17 @@ public class WorldUtils
             if (!hasProperty1)
                 continue;
 
-            Litematica.logger.info("Restricted protocol: property " + property.getName());
-            Litematica.logger.info("Restricted protocol: state1 " + state1.get(property));
-            Litematica.logger.info("Restricted protocol: state2 " + state2.get(property));
-
             if (state1.get(property) != state2.get(property))
                 return false;
         }
 
         //Other properties are considered as matching
-        Litematica.logger.info("Restricted protocol: considered matching");
         return true;
     }
 
     private static Triple<BlockPos, Direction, Vec3d> applyRestrictedProtocol(BlockPos pos, BlockState stateSchematic, Direction sideIn, Vec3d hitVecIn, MinecraftClient mc, Hand hand)
     {
         ItemPlacementContext ctx;
-
-        Litematica.logger.info("---- Begin ----");
 
         //Handle axis and slabs first, as they are exclusive with other orientation properties
         if (stateSchematic.contains(Properties.AXIS))
@@ -815,7 +802,6 @@ public class WorldUtils
 
         if (stateSchematic.contains(Properties.BLOCK_HALF))
         {
-            Litematica.logger.info("Restricted protocol: block half - begin");
             //use floored coordinates
             double x = pos.getX();
             double y = pos.getY();
@@ -857,9 +843,6 @@ public class WorldUtils
             return getWallPlaceableOrientation(pos, stateSchematic, hitVecOut, mc, hand, isOnWall);
         }
 
-        Litematica.logger.info("Attempting placement on x " + pos.getX() + " y " + pos.getY() + " z " + pos.getZ());
-        Litematica.logger.info("with hitVec " + hitVecOut + " and side " + sideOut);
-
         var updatedHitResult = new BlockHitResult(hitVecOut, sideOut, pos, false);
         ctx = new ItemPlacementContext(mc.player, hand, mc.player.getStackInHand(hand), updatedHitResult);
         var attemptState = stateSchematic.getBlock().getPlacementState(ctx);
@@ -890,8 +873,6 @@ public class WorldUtils
             pos = pos.down();
         }
         BlockState stateFacing = mc.world.getBlockState(pos);
-
-        Litematica.logger.info("stateFacing: " + stateFacing);
 
         if (stateFacing == null || stateFacing.isAir())
             return null;

--- a/src/main/resources/assets/litematica/lang/en_us.json
+++ b/src/main/resources/assets/litematica/lang/en_us.json
@@ -230,6 +230,7 @@
     "litematica.gui.label.easy_place_protocol.slabs_only": "Slabs only",
     "litematica.gui.label.easy_place_protocol.v2": "Version 2",
     "litematica.gui.label.easy_place_protocol.v3": "Version 3",
+    "litematica.gui.label.easy_place_protocol.restricted": "Restricted",
 
     "litematica.gui.label.loaded_schematic.modified_on": "§6Modified on %s§r",
 


### PR DESCRIPTION
Adds Restricted protocol for Paper-based servers
- Handles several blocks - logs, stairs, bells, trapdoors, torches/banners/signs/skulls (on/off walls), redstone-related, doors, lanterns, dripleaves, and blocks alike.
- Reports failure when a mismatching orientation property would happen (player needs to move into the correct position).

Adds configuration to omit easy place's failures

Video showcase:
https://youtu.be/rUhT3Knr3bk