### PR TITLE
1.17 cherry picks

### DIFF
--- a/src/main/java/fi/dy/masa/litematica/config/Configs.java
+++ b/src/main/java/fi/dy/masa/litematica/config/Configs.java
@@ -43,7 +43,6 @@ public class Configs implements IConfigHandler
         public static final ConfigBoolean       EASY_PLACE_SP_HANDLING  = new ConfigBoolean(    "easyPlaceSinglePlayerHandling", true, "If enabled, then Litematica handles the so called\n\"Carpet mod Accurate Block Placement Protocol\" itself in single player.\nIf you also have Tweakeroo installed, then this can be disabled,\nas Tweakeroo's 'clientPlacementRotation' option does the exact same thing.");
         public static final ConfigOptionList    EASY_PLACE_PROTOCOL     = new ConfigOptionList( "easyPlaceProtocolVersion", EasyPlaceProtocol.AUTO, "The type of \"accurate placement protocol\" to use.\n- Auto: Uses v3 in single player, and Slabs-only in multiplayer.\n- Version 3: Only supported by Litematica itself (in single player).\n- Version 2: Compatible with Carpet mod.\n- Slabs only: Only fixes top slabs. Compatible with Paper servers.\n- None: Does not modify coordinates.");
         public static final ConfigInteger       EASY_PLACE_SWAP_INTERVAL = new ConfigInteger(    "easyPlaceSwapInterval", 0, 0, 10000, "The interval in milliseconds the Easy Place mode waits\nafter swapping inventory slots and placing a block.\nUseful to avoid placing wrong blocks when having high ping.");
-        public static final ConfigBoolean       EASY_PLACE_VANILLA_REACH  = new ConfigBoolean(    "easyPlaceVanillaReach", false, "If enabled, reduces reach distance from 6 to 4.5\nso servers don't reject placement of far blocks.");
         public static final ConfigBoolean       EXECUTE_REQUIRE_TOOL    = new ConfigBoolean(    "executeRequireHoldingTool", true, "Require holding an enabled tool item\nfor the executeOperation hotkey to work");
         public static final ConfigBoolean       FIX_RAIL_ROTATION       = new ConfigBoolean(    "fixRailRotation", true, "If true, then a fix is applied for the vanilla bug in rails,\nwhere the 180 degree rotations of straight north-south and\neast-west rails rotate 90 degrees counterclockwise instead >_>");
         public static final ConfigBoolean       GENERATE_LOWERCASE_NAMES = new ConfigBoolean(   "generateLowercaseNames", false, "If enabled, then by default the suggested schematic names\nwill be lowercase and using underscores instead of spaces");
@@ -81,7 +80,6 @@ public class Configs implements IConfigHandler
                 EASY_PLACE_MODE,
                 EASY_PLACE_SP_HANDLING,
                 EASY_PLACE_PROTOCOL,
-                EASY_PLACE_VANILLA_REACH,
                 EXECUTE_REQUIRE_TOOL,
                 FIX_RAIL_ROTATION,
                 GENERATE_LOWERCASE_NAMES,

--- a/src/main/java/fi/dy/masa/litematica/event/InputHandler.java
+++ b/src/main/java/fi/dy/masa/litematica/event/InputHandler.java
@@ -293,17 +293,9 @@ public class InputHandler implements IKeybindProvider, IKeyboardInputHandler, IM
                     return SchematicUtils.placeSchematicBlock(mc);
                 }
             }
-            else if (Configs.Generic.PICK_BLOCK_ENABLED.getBooleanValue())
+            else
             {
-                if (KeybindMulti.hotkeyMatchesKeybind(Hotkeys.PICK_BLOCK_LAST, mc.options.keyUse))
-                {
-                    WorldUtils.doSchematicWorldPickBlock(false, mc);
-                }
-            }
-
-            if (Configs.Generic.PLACEMENT_RESTRICTION.getBooleanValue())
-            {
-                return WorldUtils.handlePlacementRestriction(mc);
+                WorldUtils.setIsFirstClickEasyPlace();
             }
         }
 

--- a/src/main/java/fi/dy/masa/litematica/event/KeyCallbacks.java
+++ b/src/main/java/fi/dy/masa/litematica/event/KeyCallbacks.java
@@ -262,11 +262,7 @@ public class KeyCallbacks
                 }
             }
 
-            if (key == Hotkeys.EASY_PLACE_ACTIVATION.getKeybind())
-            {
-                return WorldUtils.handleEasyPlace(this.mc);
-            }
-            else if (key == Hotkeys.OPEN_GUI_MAIN_MENU.getKeybind())
+            if (key == Hotkeys.OPEN_GUI_MAIN_MENU.getKeybind())
             {
                 GuiBase.openGui(new GuiMainMenu());
                 return true;

--- a/src/main/java/fi/dy/masa/litematica/mixin/MixinClientPlayerInteractionManager.java
+++ b/src/main/java/fi/dy/masa/litematica/mixin/MixinClientPlayerInteractionManager.java
@@ -1,0 +1,67 @@
+package fi.dy.masa.litematica.mixin;
+
+import fi.dy.masa.litematica.util.WorldUtils;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import fi.dy.masa.litematica.config.Configs;
+
+@Mixin(ClientPlayerInteractionManager.class)
+public abstract class MixinClientPlayerInteractionManager
+{
+    @Shadow @Final private net.minecraft.client.MinecraftClient client;
+
+    @Inject(method = "interactBlock", at = @At("HEAD"), cancellable = true)
+    private void onInteractBlock(ClientPlayerEntity player, ClientWorld world, Hand hand, BlockHitResult hitResult,
+            CallbackInfoReturnable<ActionResult> cir)
+    {
+        // Prevent recursion, since the Easy Place mode can call this code again
+        if (WorldUtils.isHandlingEasyPlace() == false)
+        {
+            if (WorldUtils.shouldDoEasyPlaceActions())
+            {
+                if (WorldUtils.handleEasyPlaceWithMessage(this.client))
+                {
+                    cir.setReturnValue(net.minecraft.util.ActionResult.FAIL);
+                }
+            }
+            else
+            {
+                if (Configs.Generic.PLACEMENT_RESTRICTION.getBooleanValue())
+                {
+                    if (WorldUtils.handlePlacementRestriction(this.client))
+                    {
+                        cir.setReturnValue(net.minecraft.util.ActionResult.FAIL);
+                    }
+                }
+            }
+        }
+    }
+
+    // Handle right clicks on air, which needs to happen for Easy Place mode
+    @Inject(method = "interactItem", cancellable = true, at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;syncSelectedSlot()V"))
+    private void onInteractItem(PlayerEntity player, World world, Hand hand, CallbackInfoReturnable<ActionResult> cir)
+    {
+        // Prevent recursion, since the Easy Place mode can call this code again
+        if (WorldUtils.isHandlingEasyPlace() == false)
+        {
+            if (WorldUtils.shouldDoEasyPlaceActions() &&
+                    WorldUtils.handleEasyPlaceWithMessage(this.client))
+            {
+                cir.setReturnValue(ActionResult.FAIL);
+            }
+        }
+    }
+}

--- a/src/main/java/fi/dy/masa/litematica/mixin/MixinMinecraftClient.java
+++ b/src/main/java/fi/dy/masa/litematica/mixin/MixinMinecraftClient.java
@@ -18,16 +18,12 @@ public abstract class MixinMinecraftClient extends ReentrantThreadExecutor<Runna
         super(string_1);
     }
 
-    @Inject(method = "doItemUse()V", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/item/ItemStack;getCount()I", ordinal = 0), cancellable = true)
-    private void handlePlacementRestriction(CallbackInfo ci)
+    @Inject(method = "doItemUse()V", at = @At("TAIL"))
+    private void onRightClickMouseTail(CallbackInfo ci)
     {
-        if (Configs.Generic.PLACEMENT_RESTRICTION.getBooleanValue())
+        if (WorldUtils.shouldDoEasyPlaceActions())
         {
-            if (WorldUtils.handlePlacementRestriction((MinecraftClient)(Object) this))
-            {
-                ci.cancel();
-            }
+            WorldUtils.onRightClickTail((MinecraftClient)(Object) this);
         }
     }
 

--- a/src/main/java/fi/dy/masa/litematica/scheduler/TaskScheduler.java
+++ b/src/main/java/fi/dy/masa/litematica/scheduler/TaskScheduler.java
@@ -182,8 +182,16 @@ public class TaskScheduler
     {
         synchronized (this)
         {
-            task.stop();
-            return this.tasks.remove(task);
+            int index = this.tasks.indexOf(task);
+
+            if (index >= 0)
+            {
+                task.stop();
+                this.tasks.remove(index);
+                return true;
+            }
+
+            return false;
         }
     }
 

--- a/src/main/java/fi/dy/masa/litematica/scheduler/TaskScheduler.java
+++ b/src/main/java/fi/dy/masa/litematica/scheduler/TaskScheduler.java
@@ -172,7 +172,10 @@ public class TaskScheduler
 
     public ImmutableList<ITask> getAllTasks()
     {
-        return ImmutableList.copyOf(this.tasks);
+        synchronized (this)
+        {
+            return ImmutableList.copyOf(this.tasks);
+        }
     }
 
     public boolean removeTask(ITask task)

--- a/src/main/java/fi/dy/masa/litematica/util/InventoryUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/InventoryUtils.java
@@ -2,6 +2,8 @@ package fi.dy.masa.litematica.util;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.player.PlayerEntity;
@@ -26,16 +28,41 @@ public class InventoryUtils
     {
         PICK_BLOCKABLE_SLOTS.clear();
         String[] parts = configStr.split(",");
+        Pattern patternRange = Pattern.compile("^(?<start>[0-9])-(?<end>[0-9])$");
 
         for (String str : parts)
         {
             try
             {
-                int slotNum = Integer.parseInt(str);
+                Matcher matcher = patternRange.matcher(str);
 
-                if (PlayerInventory.isValidHotbarIndex(slotNum) && PICK_BLOCKABLE_SLOTS.contains(slotNum) == false)
+                if (matcher.matches())
                 {
-                    PICK_BLOCKABLE_SLOTS.add(slotNum);
+                    int slotStart = Integer.parseInt(matcher.group("start"));
+                    int slotEnd = Integer.parseInt(matcher.group("end"));
+
+                    if (slotStart <= slotEnd &&
+                        PlayerInventory.isValidHotbarIndex(slotStart - 1) &&
+                        PlayerInventory.isValidHotbarIndex(slotEnd - 1))
+                    {
+                        for (int slotNum = slotStart; slotNum <= slotEnd; ++slotNum)
+                        {
+                            if (PICK_BLOCKABLE_SLOTS.contains(slotNum) == false)
+                            {
+                                PICK_BLOCKABLE_SLOTS.add(slotNum);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    int slotNum = Integer.parseInt(str);
+
+                    if (PlayerInventory.isValidHotbarIndex(slotNum - 1) &&
+                        PICK_BLOCKABLE_SLOTS.contains(slotNum) == false)
+                    {
+                        PICK_BLOCKABLE_SLOTS.add(slotNum);
+                    }
                 }
             }
             catch (NumberFormatException e)

--- a/src/main/java/fi/dy/masa/litematica/util/WorldUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/WorldUtils.java
@@ -756,10 +756,12 @@ public class WorldUtils
     {
         boolean cancel = placementRestrictionInEffect(mc);
 
-        if (cancel)
+        if (cancel && isFirstClickPlacementRestriction)
         {
-            InfoUtils.showGuiOrInGameMessage(MessageType.WARNING, "litematica.message.placement_restriction_fail");
+            InfoUtils.showGuiOrInGameMessage(MessageType.WARNING, 1000, "litematica.message.placement_restriction_fail");
         }
+
+        isFirstClickPlacementRestriction = false;
 
         return cancel;
     }

--- a/src/main/java/fi/dy/masa/litematica/util/WorldUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/WorldUtils.java
@@ -394,7 +394,7 @@ public class WorldUtils
     private static ActionResult doEasyPlaceAction(MinecraftClient mc)
     {
         RayTraceWrapper traceWrapper;
-        double traceMaxRange = Configs.Generic.EASY_PLACE_VANILLA_REACH.getBooleanValue() ? 4.5 : 6;
+        double traceMaxRange = mc.interactionManager.getReachDistance();
 
         if (Configs.Generic.EASY_PLACE_FIRST.getBooleanValue())
         {

--- a/src/main/resources/mixins.litematica.json
+++ b/src/main/resources/mixins.litematica.json
@@ -13,6 +13,7 @@
 		"MixinBlock",
 		"MixinBlockItem",
 		"MixinBlockStateFlattening",
+		"MixinClientPlayerInteractionManager",
 		"MixinClientPlayNetworkHandler",
 		"MixinClientWorld",
 		"MixinDebugHud",


### PR DESCRIPTION
Brought fixes from master branch:
- Task Scheduler: add missing synchronized block
- Task Scheduler: fix calling stop() twice
- Easy Place: uses mixins (interactBlock, interactItem + syncSelectedSlot, doItemUse + TAIL) and isHandlingEasyPlace to stop extra block placements and fail message spams (should fix GH #434)

Brought a feature from master branch:
- Pick block: Add number ranges in pickBlockableSlots config

Removed the config EASY_PLACE_VANILLA_REACH in favor of mc.interactionManager.getReachDistance()

Note: this does not bring fixes to underwater slabs, refactors to EasyPlaceUtils or changings in hooks for SchematicUtils / SchematicEditUtils from master branch