### PR TITLE
MaterialCache: add support for more multi-item blocks

### DIFF
--- a/src/main/java/fi/dy/masa/litematica/materials/MaterialCache.java
+++ b/src/main/java/fi/dy/masa/litematica/materials/MaterialCache.java
@@ -7,12 +7,16 @@ import net.minecraft.block.BedBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.block.CandleBlock;
 import net.minecraft.block.DoorBlock;
 import net.minecraft.block.FlowerPotBlock;
 import net.minecraft.block.FluidBlock;
+import net.minecraft.block.MultifaceGrowthBlock;
+import net.minecraft.block.SeaPickleBlock;
 import net.minecraft.block.SlabBlock;
 import net.minecraft.block.SnowBlock;
 import net.minecraft.block.TallPlantBlock;
+import net.minecraft.block.TurtleEggBlock;
 import net.minecraft.block.enums.BedPart;
 import net.minecraft.block.enums.DoubleBlockHalf;
 import net.minecraft.block.enums.SlabType;
@@ -201,13 +205,31 @@ public class MaterialCache
 
     protected void overrideStackSize(BlockState state, ItemStack stack)
     {
-        if (state.getBlock() instanceof SlabBlock && state.get(SlabBlock.TYPE) == SlabType.DOUBLE)
+        Block block = state.getBlock();
+
+        if (block instanceof SlabBlock && state.get(SlabBlock.TYPE) == SlabType.DOUBLE)
         {
             stack.setCount(2);
         }
-        else if (state.getBlock() == Blocks.SNOW)
+        else if (block == Blocks.SNOW)
         {
             stack.setCount(state.get(SnowBlock.LAYERS));
+        }
+        else if (block instanceof TurtleEggBlock)
+        {
+            stack.setCount(state.get(TurtleEggBlock.EGGS));
+        }
+        else if (block instanceof SeaPickleBlock)
+        {
+            stack.setCount(state.get(SeaPickleBlock.PICKLES));
+        }
+        else if (block instanceof CandleBlock)
+        {
+            stack.setCount(state.get(CandleBlock.CANDLES));
+        }
+        else if (block instanceof MultifaceGrowthBlock)
+        {
+            stack.setCount(MultifaceGrowthBlock.collectDirections(state).size());
         }
     }
 }


### PR DESCRIPTION
Support for the following blocks is added:

- turtle egg
- sea pickle
- candle
- glow lichen
- sculk vein

Verified to work via ` gradlew runClient`, counts correct.