### PR TITLE
Fix mod compatibility when getting registries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ logs/
 .classpath
 .project
 build.number
+
+.idea/
+run/

--- a/src/main/java/fi/dy/masa/litematica/world/SchematicWorldHandler.java
+++ b/src/main/java/fi/dy/masa/litematica/world/SchematicWorldHandler.java
@@ -10,6 +10,7 @@ import net.minecraft.registry.RegistryEntryLookup;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.world.Difficulty;
+import net.minecraft.world.World;
 import net.minecraft.world.dimension.DimensionType;
 import net.minecraft.world.dimension.DimensionTypes;
 
@@ -49,13 +50,14 @@ public class SchematicWorldHandler
 
     public static WorldSchematic createSchematicWorld(@Nullable WorldRendererSchematic worldRenderer)
     {
-        if (MinecraftClient.getInstance().world == null)
+        World world = MinecraftClient.getInstance().world;
+        if (world == null)
         {
             return null;
         }
 
         ClientWorld.Properties levelInfo = new ClientWorld.Properties(Difficulty.PEACEFUL, false, true);
-        RegistryEntryLookup.RegistryLookup lookup = BuiltinRegistries.createWrapperLookup().createRegistryLookup();
+        RegistryEntryLookup.RegistryLookup lookup = world.getRegistryManager().createRegistryLookup();
         RegistryEntry<DimensionType> entry = lookup.getOrThrow(RegistryKeys.DIMENSION_TYPE).getOrThrow(DimensionTypes.OVERWORLD);
         return new WorldSchematic(levelInfo, entry, MinecraftClient.getInstance()::getProfiler, worldRenderer);
     }


### PR DESCRIPTION
This fixes an incompatibility issue where registry keys from mods are not assigned.
This is caused by using a vanilla lookup, `BuiltinRegistries.createWrapperLookup()`.
This PR changes this to use the current world's registry manager, which contains the modded content.

Additionally, the `.idea/` and `run/` folders have been added to the `.gitignore` file.

Here is an example of the error that would occur when loading a world:
```
java.lang.IllegalStateException: Errors during registry creation
	at net.minecraft.class_7877$class_7878.method_46798(class_7877.java:137)
	at net.minecraft.class_7877.method_46780(class_7877.java:269)
	at net.minecraft.class_7887.method_46817(class_7887.java:96)
	at fi.dy.masa.litematica.world.SchematicWorldHandler.createSchematicWorld(SchematicWorldHandler.java:58)
	at fi.dy.masa.litematica.world.SchematicWorldHandler.getWorld(SchematicWorldHandler.java:44)
	at fi.dy.masa.litematica.world.SchematicWorldHandler.getSchematicWorld(SchematicWorldHandler.java:36)
	at fi.dy.masa.litematica.util.RayTraceUtils.traceToSchematicWorld(RayTraceUtils.java:339)
	at fi.dy.masa.litematica.util.RayTraceUtils.getGenericTrace(RayTraceUtils.java:366)
	at fi.dy.masa.litematica.render.OverlayRenderer.renderHoverInfo(OverlayRenderer.java:460)
	at fi.dy.masa.litematica.event.RenderHandler.onRenderGameOverlayPost(RenderHandler.java:52)
	at fi.dy.masa.malilib.event.RenderEventHandler.onRenderGameOverlayPost(RenderEventHandler.java:68)
	at net.minecraft.class_329.handler$cia000$malilib$onGameOverlayPost(class_329.java:4896)
	at net.minecraft.class_329.method_1753(class_329.java:374)
	at net.minecraft.class_757.method_3192(class_757.java:918)
	at net.minecraft.class_310.method_1523(class_310.java:1218)
	at net.minecraft.class_310.method_1514(class_310.java:801)
	at net.minecraft.client.main.Main.main(Main.java:237)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:462)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
	Suppressed: java.lang.IllegalStateException: Unreferenced key: ResourceKey[minecraft:worldgen/biome / wilderwild:mixed_forest]
		at net.minecraft.class_7877$class_7878.method_46797(class_7877.java:128)
		at net.minecraft.class_7877.method_46780(class_7877.java:268)
		... 18 more
	Suppressed: java.lang.IllegalStateException: Unreferenced key: ResourceKey[minecraft:worldgen/biome / wilderwild:jellyfish_caves]
		at net.minecraft.class_7877$class_7878.method_46797(class_7877.java:128)
		at net.minecraft.class_7877.method_46780(class_7877.java:268)
		... 18 more
	Suppressed: java.lang.IllegalStateException: Unreferenced key: ResourceKey[minecraft:worldgen/biome / wilderwild:cypress_wetlands]
		at net.minecraft.class_7877$class_7878.method_46797(class_7877.java:128)
		at net.minecraft.class_7877.method_46780(class_7877.java:268)
		... 18 more