### PR TITLE
Update Minecraft wiki link to new domain

### DIFF
--- a/src/main/java/litematica/schematic/SchematicaSchematic.java
+++ b/src/main/java/litematica/schematic/SchematicaSchematic.java
@@ -217,7 +217,7 @@ public class SchematicaSchematic extends SingleRegionSchematic
     protected boolean readBlocksFromTag(NBTTagCompound tag)
     {
         // This method was implemented based on
-        // https://minecraft.gamepedia.com/Schematic_file_format
+        // https://minecraft.wiki/w/Schematic_file_format
         // as it was on 2018-04-18.
 
         Vec3i size = this.getSize();


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the old wiki link accordingly.