### PR TITLE
GuiTextFieldGeneric.java & NbtIo fixes

### DIFF
--- a/src/main/java/fi/dy/masa/litematica/gui/GuiSchematicSaveBase.java
+++ b/src/main/java/fi/dy/masa/litematica/gui/GuiSchematicSaveBase.java
@@ -146,7 +146,8 @@ public abstract class GuiSchematicSaveBase extends GuiSchematicBrowserBase imple
     {
         super.drawContents(drawContext, mouseX, mouseY, partialTicks);
 
-        this.textField.render(drawContext, mouseX, mouseY, partialTicks);
+        // FIXME:  See malilib GuiTextFieldGeneric.java
+        this.textField.renderZ(drawContext, mouseX, mouseY, partialTicks);
     }
 
     @Override

--- a/src/main/java/fi/dy/masa/litematica/util/NbtUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/NbtUtils.java
@@ -88,7 +88,7 @@ public class NbtUtils
                 {
                     is.close();
                     is = new FileInputStream(file);
-                    nbt = NbtIo.read(file);
+                    nbt = NbtIo.read(file.toPath());
                 }
                 catch (Exception ignore) {}
             }


### PR DESCRIPTION
For 1.20.3 update, see malilib for GuiTextFieldGeneric.java for .render() call
NbtIo.read call as a Path variable.