### PR TITLE
Add Sponge Schematic V3 (.schem) IMPORT support

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+  - sdk install java 21.0.2-tem
+  - sdk use java 21.0.2-tem

--- a/src/main/java/fi/dy/masa/litematica/schematic/LitematicaSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/LitematicaSchematic.java
@@ -1405,7 +1405,6 @@ public class LitematicaSchematic
                 String msg = "Failed to read blocks from Sponge schematic";
                 InfoUtils.showGuiOrInGameMessage(MessageType.ERROR, msg);
                 Litematica.logger.error(msg);
-
                 return false;
             }
         }
@@ -1423,7 +1422,6 @@ public class LitematicaSchematic
                 String msg = "Failed to read blocks from Sponge schematic";
                 InfoUtils.showGuiOrInGameMessage(MessageType.ERROR, msg);
                 Litematica.logger.error(msg);
-
                 return false;
             }
         }

--- a/src/main/java/fi/dy/masa/litematica/schematic/LitematicaSchematic.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/LitematicaSchematic.java
@@ -1393,8 +1393,8 @@ public class LitematicaSchematic
             blocksTag = tag.getCompound("Blocks");
 
             if (blocksTag.contains("Palette", Constants.NBT.TAG_COMPOUND) &&
-                    blocksTag.contains("Data", Constants.NBT.TAG_BYTE_ARRAY) &&
-                    blocksTag.contains("BlockEntities", Constants.NBT.TAG_LIST))
+                blocksTag.contains("Data", Constants.NBT.TAG_BYTE_ARRAY) &&
+                blocksTag.contains("BlockEntities", Constants.NBT.TAG_LIST))
             {
                 paletteTag = blocksTag.getCompound("Palette");
                 blockData = blocksTag.getByteArray("Data");
@@ -1402,13 +1402,17 @@ public class LitematicaSchematic
             }
             else
             {
+                String msg = "Failed to read blocks from Sponge schematic";
+                InfoUtils.showGuiOrInGameMessage(MessageType.ERROR, msg);
+                Litematica.logger.error(msg);
+
                 return false;
             }
         }
         else
         {
             if (tag.contains("Palette", Constants.NBT.TAG_COMPOUND) &&
-                    tag.contains("BlockData", Constants.NBT.TAG_BYTE_ARRAY))
+                tag.contains("BlockData", Constants.NBT.TAG_BYTE_ARRAY))
             {
                 paletteTag = tag.getCompound("Palette");
                 blockData = tag.getByteArray("BlockData");
@@ -1416,6 +1420,10 @@ public class LitematicaSchematic
             }
             else
             {
+                String msg = "Failed to read blocks from Sponge schematic";
+                InfoUtils.showGuiOrInGameMessage(MessageType.ERROR, msg);
+                Litematica.logger.error(msg);
+
                 return false;
             }
         }

--- a/src/main/java/fi/dy/masa/litematica/schematic/conversion/SchematicConversionFixers.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/conversion/SchematicConversionFixers.java
@@ -47,7 +47,13 @@ import fi.dy.masa.malilib.util.Constants;
 public class SchematicConversionFixers
 {
     private static final BooleanProperty[] HORIZONTAL_CONNECTING_BLOCK_PROPS = new BooleanProperty[] { null, null, HorizontalConnectingBlock.NORTH, HorizontalConnectingBlock.SOUTH, HorizontalConnectingBlock.WEST, HorizontalConnectingBlock.EAST };
-    private static final BlockState REDSTONE_WIRE_DOT = Blocks.REDSTONE_WIRE.getDefaultState();
+    private static final BlockState REDSTONE_WIRE_DOT_OLD = Blocks.REDSTONE_WIRE.getDefaultState();
+    private static final BlockState REDSTONE_WIRE_DOT = Blocks.REDSTONE_WIRE.getDefaultState()
+                          .with(RedstoneWireBlock.POWER, 0)
+                          .with(RedstoneWireBlock.WIRE_CONNECTION_NORTH, WireConnection.NONE)
+                          .with(RedstoneWireBlock.WIRE_CONNECTION_EAST, WireConnection.NONE)
+                          .with(RedstoneWireBlock.WIRE_CONNECTION_SOUTH, WireConnection.NONE)
+                          .with(RedstoneWireBlock.WIRE_CONNECTION_WEST, WireConnection.NONE);
     private static final BlockState REDSTONE_WIRE_CROSS = Blocks.REDSTONE_WIRE.getDefaultState()
                           .with(RedstoneWireBlock.WIRE_CONNECTION_NORTH, WireConnection.SIDE)
                           .with(RedstoneWireBlock.WIRE_CONNECTION_EAST, WireConnection.SIDE)
@@ -342,7 +348,7 @@ public class SchematicConversionFixers
         state = ((IMixinRedstoneWireBlock) wire).litematicaGetPlacementState(reader, state, pos);
 
         // Turn all old dots into crosses, while keeping the power level
-        if (state.with(RedstoneWireBlock.POWER, 0) == REDSTONE_WIRE_DOT)
+        if (state.equals(REDSTONE_WIRE_DOT) == false && state.with(RedstoneWireBlock.POWER, 0) == REDSTONE_WIRE_DOT_OLD)
         {
             state = REDSTONE_WIRE_CROSS.with(RedstoneWireBlock.POWER, state.get(RedstoneWireBlock.POWER));
         }

--- a/src/main/java/fi/dy/masa/litematica/util/SchematicPlacingUtils.java
+++ b/src/main/java/fi/dy/masa/litematica/util/SchematicPlacingUtils.java
@@ -11,11 +11,14 @@ import net.minecraft.block.Blocks;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.decoration.AbstractDecorationEntity;
 import net.minecraft.entity.decoration.DisplayEntity;
+import net.minecraft.entity.decoration.ItemFrameEntity;
 import net.minecraft.entity.decoration.painting.PaintingEntity;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtList;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.BlockMirror;
 import net.minecraft.util.BlockRotation;
@@ -36,6 +39,7 @@ import fi.dy.masa.litematica.schematic.LitematicaSchematic.EntityInfo;
 import fi.dy.masa.litematica.schematic.container.LitematicaBlockStateContainer;
 import fi.dy.masa.litematica.schematic.placement.SchematicPlacement;
 import fi.dy.masa.litematica.schematic.placement.SubRegionPlacement;
+import fi.dy.masa.malilib.util.Constants;
 import fi.dy.masa.malilib.util.IntBoundingBox;
 import fi.dy.masa.malilib.util.NBTUtils;
 
@@ -385,6 +389,7 @@ public class SchematicPlacingUtils
             double x = pos.x + offX;
             double y = pos.y + offY;
             double z = pos.z + offZ;
+            float[] origRot = new float[2];
 
             if (x >= minX && x < maxX && z >= minZ && z < maxZ)
             {
@@ -411,6 +416,10 @@ public class SchematicPlacingUtils
                     tag.putInt("TileY", (int) p.y);
                     tag.putInt("TileZ", (int) p.z);
                 }
+
+                NbtList rotation = tag.getList("Rotation", Constants.NBT.TAG_FLOAT);
+                origRot[0] = rotation.getFloat(0);
+                origRot[1] = rotation.getFloat(1);
 
                 Entity entity = EntityUtils.createEntityAndPassengersFromNBT(tag, world);
 
@@ -447,6 +456,14 @@ public class SchematicPlacingUtils
                         }
 
                         entity.setPosition(x, y, z);
+                    }
+                    if (entity instanceof ItemFrameEntity frameEntity)
+                    {
+                        if (frameEntity.getYaw() != origRot[0] && (frameEntity.getPitch() == 90.0F || frameEntity.getPitch() == -90.0F))
+                        {
+                            // Fix Yaw only if Pitch is +/- 90.0F (Floor, Ceiling mounted)
+                            frameEntity.setYaw(origRot[0]);
+                        }
                     }
 
                     EntityUtils.spawnEntityAndPassengersInWorld(entity, world);


### PR DESCRIPTION
See the code.  Please don't mind the inclusion of the 'minecraftDataVersion' for now, because it's meant to be used with the Vanilla Data Fixer code while reading in the Block Entities, and the Entities.