### PR TITLE
VCS file extension logic fix

### DIFF
--- a/src/main/java/fi/dy/masa/litematica/schematic/projects/SchematicProject.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/projects/SchematicProject.java
@@ -208,7 +208,7 @@ public class SchematicProject
 
                 if (fileType == FileType.UNKNOWN)
                 {
-                    fileName += ".litematic";
+                    fileName += LitematicaSchematic.FILE_EXTENSION;
                     fileType = FileType.LITEMATICA_SCHEMATIC;
                 }
 

--- a/src/main/java/fi/dy/masa/litematica/schematic/projects/SchematicProject.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/projects/SchematicProject.java
@@ -204,7 +204,7 @@ public class SchematicProject
                 this.removeCurrentPlacement();
 
                 String fileName = version.getFileName();
-                FileType fileType = FileType.fromFile(new File(this.directory, fileName));
+                FileType fileType = FileType.fromName(fileName);
 
                 if (fileType == FileType.UNKNOWN)
                 {
@@ -376,8 +376,8 @@ public class SchematicProject
 
         while (failsafe-- > 0)
         {
-            String name = nameBase + String.format("%05d", version);
-            File file = new File(this.directory, name + LitematicaSchematic.FILE_EXTENSION);
+            String name = nameBase + String.format("%05d", version) + LitematicaSchematic.FILE_EXTENSION;
+            File file = new File(this.directory, name);
 
             if (file.exists() == false)
             {

--- a/src/main/java/fi/dy/masa/litematica/util/FileType.java
+++ b/src/main/java/fi/dy/masa/litematica/util/FileType.java
@@ -12,34 +12,36 @@ public enum FileType
     SPONGE_SCHEMATIC,
     VANILLA_STRUCTURE;
 
-    public static FileType fromFile(File file)
-    {
-        if (file.isFile() && file.canRead())
-        {
-            String name = file.getName();
-
-            if (name.endsWith(".litematic"))
+    public static FileType fromName(String fileName) {
+        if (fileName.endsWith(".litematic"))
             {
                 return LITEMATICA_SCHEMATIC;
             }
-            else if (name.endsWith(".schematic"))
+            else if (fileName.endsWith(".schematic"))
             {
                 return SCHEMATICA_SCHEMATIC;
             }
-            else if (name.endsWith(".nbt"))
+            else if (fileName.endsWith(".nbt"))
             {
                 return VANILLA_STRUCTURE;
             }
-            else if (name.endsWith(".schem"))
+            else if (fileName.endsWith(".schem"))
             {
                 return SPONGE_SCHEMATIC;
             }
-            else if (name.endsWith(".json"))
+            else if (fileName.endsWith(".json"))
             {
                 return JSON;
             }
 
             return UNKNOWN;
+    }
+
+    public static FileType fromFile(File file)
+    {
+        if (file.isFile() && file.canRead())
+        {
+            return fromName(file.getName());   
         }
         else
         {


### PR DESCRIPTION
this is my proposed fix for #918 
storing the extension as part of the filename property in the project's JSON file will help to avoid a mismatch even if the future default changes
i also broke off the file extension checks into a new method to avoid opening a (non-existent) file when attempting to load VCS schematics without an extension